### PR TITLE
Use first keywindow instead of delegate window

### DIFF
--- a/ImageViewer/Source/Extensions/UIApplication.swift
+++ b/ImageViewer/Source/Extensions/UIApplication.swift
@@ -9,9 +9,8 @@
 import UIKit
 
 extension UIApplication {
-
     static var applicationWindow: UIWindow {
-        return UIApplication.shared.keyWindow!
+        return UIApplication.shared.windows.first { $0.isKeyWindow }!
     }
 
     static var isPortraitOnly: Bool {

--- a/ImageViewer/Source/UtilityFunctions.swift
+++ b/ImageViewer/Source/UtilityFunctions.swift
@@ -103,9 +103,7 @@ private func rotationAngleToMatchDeviceOrientation(_ orientation: UIDeviceOrient
 }
 
 func rotationAdjustedBounds() -> CGRect {
-
-    let applicationWindow = UIApplication.shared.delegate?.window?.flatMap { $0 }
-    guard let window = applicationWindow else { return UIScreen.main.bounds }
+    let window = UIApplication.applicationWindow
 
     if UIApplication.isPortraitOnly {
 


### PR DESCRIPTION
In SwiftUI, if the delegate window is not set, the `rotationAdjustedBounds` will return early and create a boxed image on portrait only apps.

Instead, this change grabs the first available [key window](https://stackoverflow.com/a/57899013) which seems to do the trick.